### PR TITLE
[issue-#52-auto-build-webpack] Added npm i and npm run webpack

### DIFF
--- a/.docker/drash.dockerfile
+++ b/.docker/drash.dockerfile
@@ -1,7 +1,11 @@
 FROM debian:stable-slim
 
-RUN apt update -y
-RUN apt install bash curl unzip -y
+RUN apt update -y \
+  && apt clean \
+  && apt install bash curl unzip -y \
+  && apt install -y --no-install-recommends nodejs \
+  && apt install -y --no-install-recommends npm \
+  && npm install -g npm@latest
 
 RUN curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh -s v1.0.0
 RUN export DENO_INSTALL="/root/.local"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     working_dir: /var/www/src
     ports:
       - "1667:1667"
-    command: bash -c "deno run --allow-net --allow-read --unstable app.ts"
+    command: bash -c "npm i && npm run webpack && deno run --allow-net --allow-read --unstable app.ts"
     networks:
       - drash-app-network
 


### PR DESCRIPTION
* Added `npm i` and `npm run webpack` when `docker-compose up -d` is ran

* Installed npm inside the drash container to support the above