### PR TITLE
[issue-#83-show-article-on-home-after-creation] Implemented

### DIFF
--- a/src/vue/routes/ArticleEdit.vue
+++ b/src/vue/routes/ArticleEdit.vue
@@ -130,6 +130,7 @@ export default {
           this.$store.dispatch("unsetArticle");
           this.tag_input = null;
           if (response.data.article) {
+            this.$store.dispatch("setArticle", response.data.article)
             this.$router.push({
               name: "article",
               params: { slug: response.data.article.slug }

--- a/src/vue/store/actions.js
+++ b/src/vue/store/actions.js
@@ -254,7 +254,10 @@ export default {
   },
 
   setArticle(context, article) {
-    article.tags = article.tags.split(",")
+    console.log("Handling action: setArticle")
+    if (article.tags.length > 0) {
+      article.tags = article.tags.split(",")
+    }
     context.commit("setArticle", article);
     let articles = [];
     context.getters.articles.forEach((a, i) => {


### PR DESCRIPTION
Fixes #83 

**Description**

1. You create an article
2. It sends you to the preview of the article (note: already implemented)
3. You click the home button in the header
4. You will now see your article in the list without having to do a hard refresh