### PR TITLE
Issue #84 add tag on comma

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -215,6 +215,14 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@johmun/vue-tags-input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@johmun/vue-tags-input/-/vue-tags-input-2.1.0.tgz",
+      "integrity": "sha512-Fdwfss/TqCqMJbGAkmlzKbcG/ia1MstYjhqPBj+zG7h/166tIcE1TIftUxhT9LZ+RWjRSG0EFA1UyaHQSr3k3Q==",
+      "requires": {
+        "vue": "^2.6.10"
+      }
+    },
     "@types/babel-types": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
@@ -7664,8 +7672,7 @@
     "vue": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
-      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==",
-      "dev": true
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
     "vue-axios": {
       "version": "2.1.5",

--- a/src/package.json
+++ b/src/package.json
@@ -37,5 +37,8 @@
   "scripts": {
     "webpack": "node_modules/.bin/webpack --hide-modules --env.environment=development",
     "webpack-watch": "node_modules/.bin/webpack --hide-modules --watch --env.environment=development"
+  },
+  "dependencies": {
+    "@johmun/vue-tags-input": "^2.1.0"
   }
 }

--- a/src/vue/components/TagList.vue
+++ b/src/vue/components/TagList.vue
@@ -11,7 +11,29 @@
 </template>
 
 <script>
-export default {
+  /**
+   * example usage:
+       <input id="tag-input"
+         @keypress.enter.prevent="addTag(tag_input)" // update tag state here
+       />
+       <div class="tag-list">
+         <span
+           class="tag-default tag-pill"
+           v-for="(tag, index) of tags"
+           :key="tag + index"
+         >
+           <i class="ion-close-round" @click="removeTag(tag)"> </i>
+           {{ tag }}
+         </span>
+       </div>
+       ...
+       computed: {
+         ...mapGetters([
+           "tags"
+         ])
+       }
+   */
+  export default {
   name: "TagList",
   props: {
     tags: Array

--- a/src/vue/routes/ArticleEdit.vue
+++ b/src/vue/routes/ArticleEdit.vue
@@ -38,6 +38,7 @@
                   placeholder="Enter tags"
                   v-model="tag_input"
                   @keypress.enter.prevent="addTag(tag_input)"
+                  @keyup="checkArticleTags(old_tag_input, tag_input)"
                 />
                 <div class="tag-list">
                   <span
@@ -81,6 +82,7 @@ export default {
   data() {
     return {
       tag_input: null,
+      old_tag_input: null,
       publishing_article: false,
       errors: {}
     };
@@ -154,6 +156,36 @@ export default {
     addTag(tag) {
       this.$store.dispatch("createArticleTag", tag);
       this.tag_input = null;
+    },
+    checkArticleTags(oldTagInput, tagInput) {
+      const addedCharacters = this.old_tag_input ? tagInput.length > this.old_tag_input.length : !!tagInput
+      if (addedCharacters === true) {
+        // Added characters, possibly added a tag with a comma, meaning we add it to the tag list
+        const lastChar = tagInput[tagInput.length - 1]
+        if (lastChar === ",") {
+          // they entered a new tag
+          const tags = tagInput.split(',')
+          let tag = tags[tags.length - 1]
+          if (tag === "") {
+            tag = tags[tags.length - 2]
+          }
+          this.addTag(tag)
+        }
+      } else if (addedCharacters === false) {
+        // Removed characters, possibly removed a tag
+        // const originalTags = this.tag_input.split(",")
+        // const lastOriginalTag = originalTags[originalTags.length - 1]
+        // const currentTags = tagInput.split(',')
+        // const lastCurrentTag = currentTags[currentTags.length -1]
+        // if (lastCurrentTag !== lastOriginalTag) {
+        //   console.log('you removed a tag: ' + lastOriginalTag)
+        //   this.removeTag(lastOriginalTag)
+        //   delete originalTags[originalTags.indexOf(lastOriginalTag)]
+        //   const newTagString = originalTags.join(",")
+        //   this.tag_input = newTagString
+        // }
+      }
+      this.old_tag_input = tagInput
     }
   }
 };


### PR DESCRIPTION
Fixes #84 

**Description**

* The tag input now uses a vue-tag lib, to display the tags as pills inside of the input field

* Removed unused code from the ArticleEdit component as a result of most being handled by the vue lib

* Added extra styling to keep the UI consistent

* How it looks now (after typing "js", pressing enter, then typing "ks" then pressing enter):

![image](https://user-images.githubusercontent.com/47337480/88662696-3b034100-d0d2-11ea-96d5-1d3f23eaa430.png)
