### PR TITLE
issue-73-fix-empty-article-fields

### DIFF
--- a/src/resources/articles_resource.ts
+++ b/src/resources/articles_resource.ts
@@ -200,13 +200,19 @@ class ArticlesResource extends BaseResource {
   protected async createArticle(): Promise<Drash.Http.Response> {
     const inputArticle: ArticleEntity = this.request.getBodyParam("article");
 
+    if (!inputArticle.title) {
+      return this.errorResponse(400, "You must set the article title.")
+    }
+
     let article: ArticleModel = new ArticleModel(
       inputArticle.author_id,
       inputArticle.title,
-      inputArticle.description,
-      inputArticle.body,
-      inputArticle.tags
+      inputArticle.description || "",
+      inputArticle.body || "",
+      inputArticle.tags || ""
     );
+    console.log('article to save:')
+    console.log(article)
     await article.save();
 
     if (!article) {


### PR DESCRIPTION
Fixes #73 

**Description**

* Empty fields for saved articles will not have "undefined" as a string for the empty fields (eg body and description)